### PR TITLE
Remove deprecated `tcp_nodelay()`

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -123,7 +123,6 @@ impl Connection {
 
         let client = Client::builder()
             .gzip(true)
-            .tcp_nodelay()
             .user_agent(&user_agent)
             .build()
             .map_err(Error::HttpClientError)?;

--- a/src/syncronous/methods/api/v1/streaming.rs
+++ b/src/syncronous/methods/api/v1/streaming.rs
@@ -60,7 +60,6 @@ impl<'a> GetStreaming<'a> {
 
         let custom_client = ReqwestClient::builder()
             .default_headers(headers)
-            .tcp_nodelay()
             .user_agent(self.conn.user_agent())
             .build()
             .map_err(Error::HttpClientError)?;


### PR DESCRIPTION
Changed to enable TCP_NODELAY by default since reqwest v0.10.5.

https://github.com/seanmonstar/reqwest/releases/tag/v0.10.5