### PR TITLE
Change handling for default env files

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -8,6 +8,7 @@ use crate::{
 
 
 const DEFAULT_ENV_PATH: &str = ".env";
+const DEFAULT_ENV_TEST_PATH: &str = ".env.test";
 const ENV_SERVER_URL: &str = "SERVER_URL";
 const ENV_ACCESS_TOKEN: &str = "ACCESS_TOKEN";
 const ENV_USER_AGENT: &str = "USER_AGENT";
@@ -78,7 +79,11 @@ impl Connection {
     /// - STATUS_MAX_MEDIAS is not a number
     /// - POLL_MAX_OPTIONS is not a number
     pub fn new() -> Result<Self> {
-        Self::from_file(DEFAULT_ENV_PATH)
+        if cfg!(test) {
+            Self::from_file(DEFAULT_ENV_TEST_PATH)
+        } else {
+            Self::from_file(DEFAULT_ENV_PATH)
+        }
     }
 
     /// Constructs a new `Connection` using specified configuration file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,32 +10,34 @@
 //! # use std::error::Error;
 //! #
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//!     use mastors::Method;
+//! use mastors::Method;
 //! 
-//!     let conn = mastors::Connection::new()?;
+//! # // cfg(test) is not set during doctests
+//! # // https://github.com/rust-lang/rust/issues/45599
+//! let conn = mastors::Connection::from_file(".env.test")?;
 //! 
-//!     let instance = mastors::api::v1::instance::get(&conn).send()?;
+//! let instance = mastors::api::v1::instance::get(&conn).send()?;
 //! 
-//!     println!("{:#?}", instance);
+//! println!("{:#?}", instance);
 //! 
-//!     let posted_status = mastors::api::v1::statuses::post(&conn, "Toot!")
-//!         .spoiler_text("Spoiler!")
-//!         .unlisted()
-//!         .send()?
-//!         .status()
-//!         .unwrap();
+//! let posted_status = mastors::api::v1::statuses::post(&conn, "Toot!")
+//!     .spoiler_text("Spoiler!")
+//!     .unlisted()
+//!     .send()?
+//!     .status()
+//!     .unwrap();
 //! 
-//!     println!("{:#?}", posted_status);
+//! println!("{:#?}", posted_status);
 //! 
-//!     let got_status = mastors::api::v1::statuses::id::get(&conn, posted_status.id())
-//!         .send()?;
+//! let got_status = mastors::api::v1::statuses::id::get(&conn, posted_status.id())
+//!     .send()?;
 //! 
-//!     assert_eq!(posted_status.id(), got_status.id());
+//! assert_eq!(posted_status.id(), got_status.id());
 //! 
-//!     let deleted_status = mastors::api::v1::statuses::id::get(&conn, got_status.id())
-//!         .send()?;
+//! let deleted_status = mastors::api::v1::statuses::id::get(&conn, got_status.id())
+//!     .send()?;
 //! 
-//!     assert_eq!(got_status.id(), deleted_status.id());
+//! assert_eq!(got_status.id(), deleted_status.id());
 //! #
 //! # Ok(())
 //! # }
@@ -57,7 +59,10 @@
 //! # use std::error::Error;
 //! #
 //! # fn main() -> Result<(), Box<dyn Error> {
-//! let conn = mastors::Connection::new()?;
+//! 
+//! # // cfg(test) is not set during doctests
+//! # // https://github.com/rust-lang/rust/issues/45599
+//! let conn = mastors::Connection::from_file(".env.test")?;
 //! let home_timeline = get(&conn, StreamType::User).send()?;
 //! 
 //! for event in home_timeline {
@@ -125,6 +130,3 @@ pub use current_mode::{
     },
     streaming_timeline,
 };
-
-#[cfg(test)]
-pub(crate) const ENV_TEST: &str = ".env.test";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //!     use mastors::Method;
 //! 
-//!     let conn = mastors::Connection::from_file(".env")?;
+//!     let conn = mastors::Connection::new()?;
 //! 
 //!     let instance = mastors::api::v1::instance::get(&conn).send()?;
 //! 
@@ -57,7 +57,7 @@
 //! # use std::error::Error;
 //! #
 //! # fn main() -> Result<(), Box<dyn Error> {
-//! let conn = mastors::Connection::from_file(".env")?;
+//! let conn = mastors::Connection::new()?;
 //! let home_timeline = get(&conn, StreamType::User).send()?;
 //! 
 //! for event in home_timeline {

--- a/src/syncronous/methods/api/v1/custom_emojis.rs
+++ b/src/syncronous/methods/api/v1/custom_emojis.rs
@@ -30,7 +30,7 @@ mod tests {
 
     #[test]
     fn test_custom_emojis() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         get(&conn).send().unwrap();
     }
 }

--- a/src/syncronous/methods/api/v1/instance.rs
+++ b/src/syncronous/methods/api/v1/instance.rs
@@ -91,19 +91,19 @@ mod tests {
 
     #[test]
     fn test_get_instance() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         get(&conn).send().unwrap();
     }
 
     #[test]
     fn test_get_peers() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         peers::get(&conn).send().unwrap();
     }
 
     #[test]
     fn test_get_activity() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         activity::get(&conn).send().unwrap();
     }
 }

--- a/src/syncronous/methods/api/v1/media.rs
+++ b/src/syncronous/methods/api/v1/media.rs
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_upload_image() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         let posted = post(&conn, "./test-resources/test1.png")
             .description("bar board")
             .focus(0f64, 1.0f64)

--- a/src/syncronous/methods/api/v1/polls.rs
+++ b/src/syncronous/methods/api/v1/polls.rs
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn test_vote_to_poll() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         let posted = crate::api::v1::statuses::post_with_poll(&conn, "test_vote_to_poll", ["a", "b", "c"], 3600)
             .poll_multiple()
             .send()

--- a/src/syncronous/methods/api/v1/scheduled_statuses.rs
+++ b/src/syncronous/methods/api/v1/scheduled_statuses.rs
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_get_scheduled_status() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         let scheduled_at = Utc::now() + Duration::seconds(310);
 
         // Clear all existing scheduled statuses.

--- a/src/syncronous/methods/api/v1/statuses/mod.rs
+++ b/src/syncronous/methods/api/v1/statuses/mod.rs
@@ -574,7 +574,7 @@ mod tests {
 
     #[test]
     fn test_statuses() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         let content = body("toot!");
         let posted = post(&conn, &content)
             .spoiler_text("spoiler text")
@@ -604,7 +604,7 @@ mod tests {
 
     #[test]
     fn test_statuses_with_poll() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         let content = body("with poll!");
         let posted = post_with_poll(&conn, &content, &(vec!["poll1", "poll2", "poll3"]), 3600)
             .poll_multiple()
@@ -634,7 +634,7 @@ mod tests {
     fn test_status_with_attachment() {
         use crate::api::v1::media;
 
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         let content = body("with attachment!");
 
         let media_ids = vec![
@@ -675,7 +675,7 @@ mod tests {
 
     #[test]
     fn test_scheduled_status() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         let scheduled_at = Utc::now() + crate::Duration::seconds(310);
         let posted = post(&conn, body("scheduled!"))
             .scheduled_at(scheduled_at)
@@ -717,7 +717,7 @@ mod tests {
 
     #[test]
     fn test_scheduled_status_with_media() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         let scheduled_at = Utc::now() + crate::Duration::seconds(310);
         let media_ids = vec![
             crate::api::v1::media::post(&conn, "./test-resources/test1.png").send().unwrap().id().to_owned(),
@@ -743,7 +743,7 @@ mod tests {
 
     #[test]
     fn test_scheduled_status_with_poll() {
-        let conn = Connection::from_file(crate::ENV_TEST).unwrap();
+        let conn = Connection::new().unwrap();
         let scheduled_at = Utc::now() + crate::Duration::seconds(310);
         let posted = post_with_poll(&conn, "scheduled status with poll", ["a", "b"], 3600)
             .scheduled_at(scheduled_at)


### PR DESCRIPTION
Change to automatically switch between `.env` and `.env.test` depending on whether it is set `cfg (test)`.