### PR TITLE
Remove excess `pub use`s

### DIFF
--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -1,14 +1,13 @@
 use serde::Deserialize;
 use crate::utils::transform_option_str_to_enum;
-use super::Entity;
-
-pub use crate::{
+use crate::{
     DateTime,
     Utc,
     Url,
 };
-pub use super::{
+use super::{
     Emoji,
+    Entity,
     Privacy,
 };
 

--- a/src/entities/attachment.rs
+++ b/src/entities/attachment.rs
@@ -1,8 +1,10 @@
 use serde::Deserialize;
-use crate::utils::transform_str_to_enum;
+use crate::{
+    Url,
+    utils::transform_str_to_enum,
+};
 use super::Entity;
 
-pub use crate::Url;
 
 /// Represents a file or media attachment that can be added to a status.
 #[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]

--- a/src/entities/card.rs
+++ b/src/entities/card.rs
@@ -1,8 +1,9 @@
 use serde::Deserialize;
-use crate::utils::transform_str_to_enum;
+use crate::{
+    Url,
+    utils::transform_str_to_enum,
+};
 use super::Entity;
-
-pub use crate::Url;
 
 /// Represents a rich preview card that is generated using OpenGraph tags from a URL.
 #[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize)]

--- a/src/entities/emoji.rs
+++ b/src/entities/emoji.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
+use crate::Url;
 use super::Entity;
 
-pub use crate::Url;
 
 /// Represents a custom emoji.
 #[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize)]

--- a/src/entities/instance.rs
+++ b/src/entities/instance.rs
@@ -1,8 +1,9 @@
 use serde::Deserialize;
-use super::Entity;
-
-pub use crate::Url;
-pub use super::Account;
+use crate::Url;
+use super::{
+    Account,
+    Entity,
+};
 
 /// Represents the software instance of Mastodon running on this domain.
 #[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]

--- a/src/entities/mention.rs
+++ b/src/entities/mention.rs
@@ -1,7 +1,6 @@
 use serde::Deserialize;
+use crate::Url;
 use super::Entity;
-
-pub use crate::Url;
 
 /// Represents a mention of a user within the content of a status.
 #[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]

--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -1,14 +1,13 @@
 use serde::Deserialize;
-use crate::utils::transform_str_to_enum;
-use super::Entity;
-
-pub use crate::{
+use crate::{
     DateTime,
     Error,
     Utc,
+    utils::transform_str_to_enum,
 };
-pub use super::{
+use super::{
     Account,
+    Entity,
     Status,
 };
 

--- a/src/entities/poll.rs
+++ b/src/entities/poll.rs
@@ -1,12 +1,11 @@
 use serde::Deserialize;
-use super::Entity;
-
-pub use crate::{
+use crate::{
     DateTime,
     Utc,
 };
-pub use super::{
+use super::{
     Emoji,
+    Entity,
 };
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]

--- a/src/entities/status.rs
+++ b/src/entities/status.rs
@@ -1,18 +1,17 @@
 use serde::Deserialize;
-use crate::utils::transform_str_to_enum;
-use super::Entity;
-
-pub use crate::{
+use crate::{
     DateTime,
     Utc,
     Url,
+    utils::transform_str_to_enum,
 };
-pub use super::{
+use super::{
     Account,
     Application,
     Attachment,
     Card,
     Emoji,
+    Entity,
     Mention,
     Poll,
     Tag,

--- a/src/entities/tag.rs
+++ b/src/entities/tag.rs
@@ -1,8 +1,9 @@
 use serde::Deserialize;
-use super::Entity;
-
-pub use crate::Url;
-pub use super::History;
+use crate::Url;
+use super::{
+    Entity,
+    History,
+};
 
 /// Represents a hashtag used within the content of a status.
 #[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,8 @@
 //! ```no_run
 //! //! This is a simple streaming timeline on the command-line terminal.
 //! use mastors::Method;
-//! use mastors::api::v1::streaming::{
-//!     EventType,
-//!     StreamType,
-//!     get,
-//! };
+//! use mastors::api::v1::streaming::get;
+//! use mastors::streaming_timeline::*;
 //!
 //! # use std::error::Error;
 //! #

--- a/src/syncronous/methods/api/v1/accounts/mod.rs
+++ b/src/syncronous/methods/api/v1/accounts/mod.rs
@@ -23,12 +23,6 @@ pub fn post(
     unimplemented!()
 }
 
-pub use id::followers::get as get_followers_by_account_id;
-pub use id::following::get as get_following_by_account_id;
-pub use id::identity_proofs::get as get_identity_proofs_by_account_id;
-pub use id::lists::get as get_lists_by_account_id;
-pub use id::statuses::get as get_statuses_by_account_id;
-
 /// Post request for `/api/v1/accounts` used to create an account.
 #[derive(Debug, Clone, Serialize, mastors_derive::Method)]
 #[method_params(POST, Account, "/api/v1/accounts")]

--- a/src/syncronous/methods/api/v1/polls.rs
+++ b/src/syncronous/methods/api/v1/polls.rs
@@ -1,15 +1,5 @@
 //! This module provides features related to poll attached to status.
 
-/// Get a request to get a poll specified by ID.
-/// 
-/// This function is an alias of `mastors::api::v1::polls::id::get()`.
-pub use id::get as get_by_id;
-
-/// Get a request to post vote to the poll specified by ID.
-/// 
-/// This function is an alias of `mastors::api::v1::polls::id::votes::post()`.
-pub use id::votes::post as post_with_id;
-
 /// This module provides features related to poll specified by ID.
 pub mod id {
     use serde::Serialize;
@@ -154,11 +144,11 @@ mod tests {
             .status()
             .unwrap();
 
-        let voted = super::post_with_id(&conn, posted.poll().unwrap().id(), [0, 1])
+        let voted = super::id::votes::post(&conn, posted.poll().unwrap().id(), [0, 1])
             .send()
             .unwrap();
 
-        let got = super::get_by_id(&conn, voted.id())
+        let got = super::id::get(&conn, voted.id())
             .authorized()
             .send()
             .unwrap();
@@ -171,13 +161,13 @@ mod tests {
         assert_eq!(got_option_0.title(), "a");
         assert_eq!(got_option_0.votes_count().unwrap(), 1);
 
-        let got = super::get_by_id(&conn, voted.id())
+        let got = super::id::get(&conn, voted.id())
             .send()
             .unwrap();
 
         assert!(got.voted().is_none());
 
-        let _deleted = crate::api::v1::statuses::delete_by_id(&conn, posted.id())
+        let _deleted = crate::api::v1::statuses::id::delete(&conn, posted.id())
             .send()
             .unwrap();
     }

--- a/src/syncronous/methods/api/v1/scheduled_statuses.rs
+++ b/src/syncronous/methods/api/v1/scheduled_statuses.rs
@@ -18,10 +18,6 @@ pub fn get(conn: &Connection) -> GetScheduledStatuses {
     }
 }
 
-pub use id::get as get_by_id;
-pub use id::put as put_by_id;
-pub use id::delete as delete_by_id;
-
 /// GET request for scheduled statuses that are created by authenticated user.
 #[derive(Debug, Clone, Serialize, mastors_derive::Method)]
 #[method_params(GET, ScheduledStatuses, "/api/v1/scheduled_statuses")]

--- a/src/syncronous/methods/api/v1/statuses/mod.rs
+++ b/src/syncronous/methods/api/v1/statuses/mod.rs
@@ -71,9 +71,6 @@ where
     )
 }
 
-pub use id::get as get_by_id;
-pub use id::delete as delete_by_id;
-
 // Create POST request.
 fn post_internal(
     conn: &Connection,
@@ -598,7 +595,7 @@ mod tests {
             .send()
             .unwrap();
 
-        let got = get_by_id(&conn, posted.id())
+        let got = super::id::get(&conn, posted.id())
             .authorized()
             .unauthorized()
             .authorized()
@@ -607,7 +604,7 @@ mod tests {
 
         assert_eq!(posted.id(), got.id());
 
-        let deleted = delete_by_id(&conn, posted.id())
+        let deleted = super::id::delete(&conn, posted.id())
             .send()
             .unwrap();
 
@@ -626,7 +623,7 @@ mod tests {
             .unwrap();
         let posted = posted.status().unwrap();
 
-        let got = get_by_id(&conn, posted.id())
+        let got = super::id::get(&conn, posted.id())
             .authorized()
             .send()
             .unwrap();
@@ -634,7 +631,7 @@ mod tests {
         assert_eq!(posted.id(), got.id());
         assert_eq!(posted.poll().unwrap().id(), got.poll().unwrap().id());
 
-        let deleted = delete_by_id(&conn, posted.id())
+        let deleted = super::id::delete(&conn, posted.id())
             .send()
             .unwrap();
 
@@ -659,7 +656,7 @@ mod tests {
             .send()
             .unwrap();
 
-        let got = get_by_id(&conn, posted.id())
+        let got = super::id::get(&conn, posted.id())
             .send()
             .unwrap();
 
@@ -672,7 +669,7 @@ mod tests {
         assert_eq!(posted.id(), got.id());
         assert_eq!(&media_ids, &got_media_ids);
 
-        let deleted = delete_by_id(&conn, got.id())
+        let deleted = super::id::delete(&conn, got.id())
             .send()
             .unwrap();
 

--- a/src/syncronous/methods/api/v1/streaming.rs
+++ b/src/syncronous/methods/api/v1/streaming.rs
@@ -16,10 +16,9 @@ use crate::{
         Notification,
         Status,
     },
+    streaming_timeline::*,
     utils,
 };
-
-pub use crate::streaming_timeline::*;
 
 const ENDPOINT: &str = "/api/v1/streaming";
 

--- a/src/syncronous/methods/api/v1/streaming.rs
+++ b/src/syncronous/methods/api/v1/streaming.rs
@@ -1,26 +1,15 @@
 //! This module provides features related to get streaming timelines.
-use eventsource::{
-    event::Event,
-    reqwest::Client,
-};
 use reqwest::{
     header,
     blocking::Client as ReqwestClient,
 };
-use serde_json;
 use crate::{
     Connection,
     Error,
     Result,
-    entities::{
-        Notification,
-        Status,
-    },
     streaming_timeline::*,
     utils,
 };
-
-const ENDPOINT: &str = "/api/v1/streaming";
 
 /// Get the event stream of the type specified by `stream_type`.
 pub fn get(conn: &Connection, stream_type: StreamType) -> GetStreaming {
@@ -62,94 +51,8 @@ impl<'a> GetStreaming<'a> {
             .user_agent(self.conn.user_agent())
             .build()
             .map_err(Error::HttpClientError)?;
-
-        Ok(SseStream{
-            client: Client::new_with_client(url, custom_client),
-        })
-    }
-}
-
-/// Stream of each timeline.
-pub struct SseStream {
-    client: Client,
-}
-
-impl StreamingTimeline for SseStream {}
-
-impl Iterator for SseStream {
-    type Item = Result<EventType>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.client.next().map(|result| {
-            match result {
-                Ok(event) => get_event_type(&event),
-                Err(e) => Err(Error::SseStreamError(e)),
-            }
-        })
-    }
-}
-
-fn get_event_type(event: &Event) -> Result<EventType> {
-    if let Some(event_type) = &event.event_type {
-        match event_type.as_str() {
-            "update" => {
-                Ok(EventType::Update(
-                    Box::new(serde_json::from_str::<Status>(&event.data)?)
-                ))
-            },
-            "notification" => {
-                Ok(EventType::Notification(
-                    Box::new(serde_json::from_str::<Notification>(&event.data)?)
-                ))
-            },
-            "delete" => {
-                Ok(EventType::Delete(event.data.to_owned()))
-            },
-            "filters_changed" => {
-                Ok(EventType::FiltersChanged)
-            },
-            _ => Err(Error::UnknownEventTypeError(event_type.to_owned()))
-        }
-    } else {
-        Ok(EventType::Unknown(event.data.to_owned()))
-    }
-}
-
-/// Represents a streaming type.
-#[derive(Debug, PartialEq, PartialOrd, Hash, Clone)]
-pub enum StreamType {
-    /// Represents stream of events that are relevant to the authorized user, i.e. home timeline and notifications.
-    User,
-    /// Represents stream of all public statuses.
-    Public,
-    /// Represents stream of all local statuses.
-    PublicLocal,
-    /// Represents stream of all public statuses without local statuses. (mastodon v3.1.4 or later)
-    PublicRemote,
-    /// Represents stream of all public statuses for a particular hashtag.
-    Hashtag(String),
-    /// Represents stream of all local statuses for a particular hashtag.
-    HashtagLocal(String),
-    /// Represents stream of all statuses for a list.
-    List(String),
-    /// Represents stream of all direct messages.
-    Direct,
-}
-
-use std::fmt;
-
-impl fmt::Display for StreamType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            StreamType::User => write!(f, "{}/user", ENDPOINT),
-            StreamType::Public => write!(f, "{}/public", ENDPOINT),
-            StreamType::PublicLocal => write!(f, "{}/public/local", ENDPOINT),
-            StreamType::PublicRemote => write!(f, "{}/public/remote", ENDPOINT),
-            StreamType::Hashtag(tag) => write!(f, "{}/hashtag?tag={}", ENDPOINT, tag),
-            StreamType::HashtagLocal(tag) => write!(f, "{}/hashtag/local?tag={}", ENDPOINT, tag),
-            StreamType::List(id) => write!(f, "{}/list?list={}", ENDPOINT, id),
-            StreamType::Direct => write!(f, "{}/direct", ENDPOINT),
-        }
+          
+        Ok(SseStream::new(url, custom_client))
     }
 }
 

--- a/src/syncronous/streaming_timeline.rs
+++ b/src/syncronous/streaming_timeline.rs
@@ -1,5 +1,11 @@
+use eventsource::{
+    event::Event,
+    reqwest::Client,
+};
 use crate::{
+    Error,
     Result,
+    Url,
     entities::{
         Notification,
         Status,
@@ -7,6 +13,34 @@ use crate::{
 };
 
 pub trait StreamingTimeline: Iterator<Item = Result<EventType>> {}
+
+/// Represents the stream of each timeline.
+pub struct SseStream {
+    client: Client,
+}
+
+impl SseStream {
+    pub fn new(url: Url, client: reqwest::blocking::Client) -> Self {
+        SseStream {
+            client: Client::new_with_client(url, client),
+        }
+    }
+}
+
+impl StreamingTimeline for SseStream {}
+
+impl Iterator for SseStream {
+    type Item = Result<EventType>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.client.next().map(|result| {
+            match result {
+                Ok(event) => get_event_type(&event),
+                Err(e) => Err(Error::SseStreamError(e)),
+            }
+        })
+    }
+}
 
 /// Represent the event types of the server-sent events of the Mastodon.
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
@@ -34,3 +68,70 @@ pub enum EventType {
     /// This event type contains received raw data as `String`.
     Unknown(String),
 }
+
+/// Represents a streaming type.
+#[derive(Debug, PartialEq, PartialOrd, Hash, Clone)]
+pub enum StreamType {
+    /// Represents stream of events that are relevant to the authorized user, i.e. home timeline and notifications.
+    User,
+    /// Represents stream of all public statuses.
+    Public,
+    /// Represents stream of all local statuses.
+    PublicLocal,
+    /// Represents stream of all public statuses without local statuses. (mastodon v3.1.4 or later)
+    PublicRemote,
+    /// Represents stream of all public statuses for a particular hashtag.
+    Hashtag(String),
+    /// Represents stream of all local statuses for a particular hashtag.
+    HashtagLocal(String),
+    /// Represents stream of all statuses for a list.
+    List(String),
+    /// Represents stream of all direct messages.
+    Direct,
+}
+
+use std::fmt;
+
+impl fmt::Display for StreamType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const ENDPOINT: &str = "/api/v1/streaming";
+
+        match self {
+            StreamType::User => write!(f, "{}/user", ENDPOINT),
+            StreamType::Public => write!(f, "{}/public", ENDPOINT),
+            StreamType::PublicLocal => write!(f, "{}/public/local", ENDPOINT),
+            StreamType::PublicRemote => write!(f, "{}/public/remote", ENDPOINT),
+            StreamType::Hashtag(tag) => write!(f, "{}/hashtag?tag={}", ENDPOINT, tag),
+            StreamType::HashtagLocal(tag) => write!(f, "{}/hashtag/local?tag={}", ENDPOINT, tag),
+            StreamType::List(id) => write!(f, "{}/list?list={}", ENDPOINT, id),
+            StreamType::Direct => write!(f, "{}/direct", ENDPOINT),
+        }
+    }
+}
+
+fn get_event_type(event: &Event) -> Result<EventType> {
+    if let Some(event_type) = &event.event_type {
+        match event_type.as_str() {
+            "update" => {
+                Ok(EventType::Update(
+                    Box::new(serde_json::from_str::<Status>(&event.data)?)
+                ))
+            },
+            "notification" => {
+                Ok(EventType::Notification(
+                    Box::new(serde_json::from_str::<Notification>(&event.data)?)
+                ))
+            },
+            "delete" => {
+                Ok(EventType::Delete(event.data.to_owned()))
+            },
+            "filters_changed" => {
+                Ok(EventType::FiltersChanged)
+            },
+            _ => Err(Error::UnknownEventTypeError(event_type.to_owned()))
+        }
+    } else {
+        Ok(EventType::Unknown(event.data.to_owned()))
+    }
+}
+


### PR DESCRIPTION
- It is better to include function aliases in the prelude.
- Excess re-exports are unnecessary.