### PR TITLE
Fix Clippy Lint warnings in Rust 1.45.0

### DIFF
--- a/src/syncronous/methods/api/v1/scheduled_statuses.rs
+++ b/src/syncronous/methods/api/v1/scheduled_statuses.rs
@@ -210,31 +210,31 @@ mod tests {
         }
 
         let posted1 = statuses::post(&conn, "first")
-            .scheduled_at(scheduled_at.clone())
+            .scheduled_at(scheduled_at)
             .send()
             .unwrap()
             .scheduled_status()
             .unwrap();
         let posted2 = statuses::post(&conn, "second")
-            .scheduled_at(scheduled_at.clone())
+            .scheduled_at(scheduled_at)
             .send()
             .unwrap()
             .scheduled_status()
             .unwrap();
         let posted3 = statuses::post(&conn, "third")
-            .scheduled_at(scheduled_at.clone())
+            .scheduled_at(scheduled_at)
             .send()
             .unwrap()
             .scheduled_status()
             .unwrap();
         let posted4 = statuses::post(&conn, "fourth")
-            .scheduled_at(scheduled_at.clone())
+            .scheduled_at(scheduled_at)
             .send()
             .unwrap()
             .scheduled_status()
             .unwrap();
         let posted5 = statuses::post(&conn, "fifth")
-            .scheduled_at(scheduled_at.clone())
+            .scheduled_at(scheduled_at)
             .send()
             .unwrap()
             .scheduled_status()

--- a/src/syncronous/methods/api/v1/statuses/mod.rs
+++ b/src/syncronous/methods/api/v1/statuses/mod.rs
@@ -709,7 +709,7 @@ mod tests {
 
         let extended_scheduled_at = *got.scheduled_at() + chrono::Duration::seconds(100);
         let put = crate::api::v1::scheduled_statuses::id::put(&conn, got.id())
-            .scheduled_at(extended_scheduled_at.clone())
+            .scheduled_at(extended_scheduled_at)
             .send()
             .unwrap();
 


### PR DESCRIPTION
Fix some `clone_on_copy` warnings.