### PR TITLE
Various fixes

### DIFF
--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -113,8 +113,8 @@ impl Account {
     }
 
     /// Get date time when this account was created.
-    pub fn created_at(&self) -> &DateTime<Utc> {
-        &self.created_at
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
     }
 
     /// Get the number of statuses which are attached to this account.

--- a/src/entities/attachment.rs
+++ b/src/entities/attachment.rs
@@ -74,6 +74,14 @@ impl Attachment {
     pub fn blurhash(&self) -> Option<&str> {
         self.blurhash.as_deref()
     }
+
+    /// Get the type of this attachment as `AttachmentType`.
+    /// 
+    /// This method is an alias of `r#type()`.
+    pub fn attachment_type(&self) -> AttachmentType {
+        self.r#type()
+    }
+
 }
 
 impl Entity for Attachment {}

--- a/src/entities/card.rs
+++ b/src/entities/card.rs
@@ -92,6 +92,13 @@ impl Card {
     pub fn embed_url(&self) -> Option<&Url> {
         self.embed_url.as_ref()
     }
+
+    /// Get the type of the preview card as `CardType`.
+    /// 
+    /// This method is an alias of `r#type()`.
+    pub fn card_type(&self) -> CardType {
+        self.r#type()
+    }
 }
 
 impl Entity for Card {}

--- a/src/entities/identity_proof.rs
+++ b/src/entities/identity_proof.rs
@@ -38,8 +38,8 @@ impl IdentityProof {
     }
 
     /// Get updated date and time of the account owner on the identity provider.
-    pub fn updated_at(&self) -> &DateTime<Utc> {
-        &self.updated_at
+    pub fn updated_at(&self) -> DateTime<Utc> {
+        self.updated_at
     }
 }
 impl Entity for IdentityProof {}

--- a/src/entities/markers.rs
+++ b/src/entities/markers.rs
@@ -41,8 +41,8 @@ impl Marker {
 	}
 
 	/// Get updated date and time of this marker.
-	pub fn updated_at(&self) -> &DateTime<Utc> {
-		&self.updated_at
+	pub fn updated_at(&self) -> DateTime<Utc> {
+		self.updated_at
 	}
 
 	/// Get a version number of this marker.

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -76,7 +76,7 @@ impl PostedStatus {
     }
 
     /// Get scheduled date and time if this status is scheduled.
-    pub fn scheduled_at(&self) -> Option<&DateTime<Utc>> {
+    pub fn scheduled_at(&self) -> Option<DateTime<Utc>> {
         match self {
             Self::Status(_) => None,
             Self::ScheduledStatus(s) => Some(s.scheduled_at()),

--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -39,8 +39,8 @@ impl Notification {
     }
 
     /// Get the timestamp of the notification.
-    pub fn created_at(&self) -> &DateTime<Utc> {
-        &self.created_at
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
     }
 
     /// Get the account that performed the action that generated the notification.
@@ -52,6 +52,14 @@ impl Notification {
     pub fn status(&self) -> Option<&Status> {
         self.status.as_deref()
     }
+
+    /// Get the type of event that resulted in the notification.
+    /// 
+    /// This method is an alias of `r#type()`.
+    pub fn notification_type(&self) -> NotificationType {
+        self.r#type()
+    }
+
 }
 
 impl Entity for Notification {}

--- a/src/entities/poll.rs
+++ b/src/entities/poll.rs
@@ -30,8 +30,8 @@ impl Poll {
     }
 
     /// Get the date time when the poll ends.
-    pub fn expires_at(&self) -> &DateTime<Utc> {
-        &self.expires_at
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
     }
 
     /// Get whether the poll currently expired.

--- a/src/entities/scheduled_status.rs
+++ b/src/entities/scheduled_status.rs
@@ -27,8 +27,8 @@ impl ScheduledStatus {
     }
 
     /// Get a scheduled date and time of this scheduled status.
-    pub fn scheduled_at(&self) -> &DateTime<Utc> {
-        &self.scheduled_at
+    pub fn scheduled_at(&self) -> DateTime<Utc> {
+        self.scheduled_at
     }
 
     /// Get a params of this scheduled status.
@@ -49,7 +49,7 @@ impl Entity for ScheduledStatus {}
 pub struct Params {
     text: String,
     application_id: u64,
-    visibility: Option<Visibility>,
+    visibility: Visibility,
     in_reply_to_id: Option<String>,
     media_ids: Option<Vec<String>>,
     sensitive: Option<bool>,
@@ -70,7 +70,7 @@ impl Params {
     }
 
     /// Get a visibility of status that will posted at scheduled date and time.
-    pub fn visibility(&self) -> Option<Visibility> {
+    pub fn visibility(&self) -> Visibility {
         self.visibility
     }
 
@@ -99,12 +99,32 @@ impl Params {
     }
 
     /// Get a scheduled date and time of this scheduled status.
-    pub fn scheduled_at(&self) -> Option<&DateTime<Utc>> {
-        self.scheduled_at.as_ref()
+    pub fn scheduled_at(&self) -> Option<DateTime<Utc>> {
+        self.scheduled_at
     }
 
     pub fn poll(&self) -> Option<&ScheduledPoll> {
         self.poll.as_ref()
+    }
+
+    /// Get whether visibility of this status is set to `public`.
+    pub fn is_public(&self) -> bool {
+        self.visibility == Visibility::Public
+    }
+
+    /// Get whether visibility of this status is set to `unlisted`.
+    pub fn is_unlisted(&self) -> bool {
+        self.visibility == Visibility::Unlisted
+    }
+
+    /// Get whether visibility of this status is set to `private`.
+    pub fn is_private(&self) -> bool {
+        self.visibility == Visibility::Private
+    }
+
+    /// Get whether visibility of this status is set to `direct`.
+    pub fn is_direct(&self) -> bool {
+        self.visibility == Visibility::Direct
     }
 }
 

--- a/src/entities/status.rs
+++ b/src/entities/status.rs
@@ -214,6 +214,26 @@ impl Status {
     pub fn pinned(&self) -> bool {
         self.pinned.unwrap_or(false)
     }
+
+    /// Get whether visibility of this status is set to `public`.
+    pub fn is_public(&self) -> bool {
+        self.visibility == Visibility::Public
+    }
+
+    /// Get whether visibility of this status is set to `unlisted`.
+    pub fn is_unlisted(&self) -> bool {
+        self.visibility == Visibility::Unlisted
+    }
+
+    /// Get whether visibility of this status is set to `private`.
+    pub fn is_private(&self) -> bool {
+        self.visibility == Visibility::Private
+    }
+
+    /// Get whether visibility of this status is set to `direct`.
+    pub fn is_direct(&self) -> bool {
+        self.visibility == Visibility::Direct
+    }
 }
 
 impl Entity for Status {}

--- a/src/synchronous/methods/api/v1/statuses/mod.rs
+++ b/src/synchronous/methods/api/v1/statuses/mod.rs
@@ -705,7 +705,7 @@ mod tests {
         assert_eq!(posted.id(), got.id());
         assert_eq!(posted.scheduled_at(), got.scheduled_at());
 
-        let extended_scheduled_at = *got.scheduled_at() + chrono::Duration::seconds(100);
+        let extended_scheduled_at = got.scheduled_at() + chrono::Duration::seconds(100);
         let put = crate::api::v1::scheduled_statuses::id::put(&conn, got.id())
             .scheduled_at(extended_scheduled_at)
             .send()


### PR DESCRIPTION
- Change return of some methods from `&DataTime<Utc>` to `DateTime<Utc>`
Because `DateTime` implements `Copy` trait.

- Add some convenient methods to entities
For example, `Status.is_public()` to useable instead of `Status.visibility() == Visibility::Public`.

- Add some alias methods to entities
For example, `Attachment.attachment_type()` as an alias of `Attachment.r#type()` because `type` is reserved word of rust.