### PR TITLE
Add feature to auto derive Entity trait

### DIFF
--- a/mastors-derive/src/lib.rs
+++ b/mastors-derive/src/lib.rs
@@ -7,6 +7,8 @@ const IDENT_PATH_PARAM: &str = "path_param";
 const IDENT_AUTHORIZATION: &str = "authorization";
 const IDENT_METHOD_PARAMS: &str = "method_params";
 
+const IDENT_ENTITY_ID: &str = "identifier";
+
 #[proc_macro_derive(Method, attributes(mastors, method_params))]
 pub fn derive_method(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
@@ -93,6 +95,39 @@ pub fn derive_method(input: TokenStream) -> TokenStream {
         }
 
         #trait_impl
+    })
+}
+
+#[proc_macro_derive(Entity, attributes(mastors))]
+pub fn derive_entity(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let name = &input.ident;
+
+    let compare_impl = match get_field_name_with_attribute(&input.data, IDENT_ENTITY_ID) {
+        Some(id_field) => quote! {
+            impl std::cmp::PartialEq<#name> for #name {
+                fn eq(&self, other: &Self) -> bool {
+                    self.#id_field == other.#id_field
+                }
+            }
+            impl std::cmp::PartialOrd<#name> for #name {
+                fn partial_cmp(&self, other: &Self) -> std::option::Option<std::cmp::Ordering> {
+                    Some(self.cmp(&other))
+                }
+            }
+            impl std::cmp::Eq for #name {}
+            impl std::cmp::Ord for #name {
+                fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                    self.#id_field.cmp(&other.#id_field)
+                }
+            }
+        },
+        None => quote! {},
+    };
+
+    TokenStream::from(quote! {
+        impl crate::entities::Entity for #name {}
+        #compare_impl
     })
 }
 

--- a/mastors-derive/src/lib.rs
+++ b/mastors-derive/src/lib.rs
@@ -121,6 +121,11 @@ pub fn derive_entity(input: TokenStream) -> TokenStream {
                     self.#id_field.cmp(&other.#id_field)
                 }
             }
+            impl std::hash::Hash for #name {
+                fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                    self.#id_field.hash(state)
+                }
+            }
         },
         None => quote! {},
     };

--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -12,7 +12,7 @@ use super::{
 };
 
 /// Represents a user of Mastodon and their associated profile.
-#[derive(Debug, Hash, Clone, Deserialize, mastors_derive::Entity)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Account {
     // Base attributes
     #[mastors(identifier)]

--- a/src/entities/account.rs
+++ b/src/entities/account.rs
@@ -12,10 +12,12 @@ use super::{
 };
 
 /// Represents a user of Mastodon and their associated profile.
-#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize)]
+#[derive(Debug, Hash, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Account {
     // Base attributes
+    #[mastors(identifier)]
     id: String, // cast from an integer, but not guaranteed to be a number
+
     username: String,
     acct: String,
     url: Url,
@@ -43,8 +45,6 @@ pub struct Account {
     bot: Option<bool>,
     source: Option<Source>,
 }
-
-impl Entity for Account {}
 
 impl Account {
     /// Get an ID of this account.

--- a/src/entities/activity.rs
+++ b/src/entities/activity.rs
@@ -3,7 +3,7 @@ use crate::utils::transform_string_to_usize;
 use super::Entity;
 
 /// Represents a weekly bucket of instance activity.
-#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Copy, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Clone, Copy, Deserialize, mastors_derive::Entity)]
 pub struct Activity {
     #[serde(deserialize_with = "transform_string_to_usize")]
     week: usize,
@@ -39,8 +39,6 @@ impl Activity {
         self.registrations
     }
 }
-
-impl Entity for Activity {}
 
 /// Represents an array of [`Activity`](./struct.Activity.html)s.
 pub type Activities = Vec<Activity>;

--- a/src/entities/application.rs
+++ b/src/entities/application.rs
@@ -1,8 +1,7 @@
 use serde::Deserialize;
-use super::Entity;
 
 /// Represents an application that interfaces with the REST API to access accounts or post statuses.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Application {
     // Required attributes
     name: String,
@@ -15,8 +14,6 @@ pub struct Application {
     client_id: Option<String>,
     client_secret: Option<String>,
 }
-
-impl Entity for Application {}
 
 impl Application {
     /// Get the name of this application.

--- a/src/entities/attachment.rs
+++ b/src/entities/attachment.rs
@@ -3,14 +3,14 @@ use crate::{
     Url,
     utils::transform_str_to_enum,
 };
-use super::Entity;
-
 
 /// Represents a file or media attachment that can be added to a status.
-#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Attachment {
     // Required attributes
+    #[mastors(identifier)]
     id: String,
+
     #[serde(deserialize_with = "transform_str_to_enum")]
     r#type: AttachmentType,
     url: crate::Url,
@@ -107,8 +107,6 @@ impl Attachment {
         self.r#type == AttachmentType::Unknown
     }
 }
-
-impl Entity for Attachment {}
 
 /// Metadata returned by Paperclip.
 #[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]

--- a/src/entities/card.rs
+++ b/src/entities/card.rs
@@ -3,10 +3,9 @@ use crate::{
     Url,
     utils::transform_str_to_enum,
 };
-use super::Entity;
 
 /// Represents a rich preview card that is generated using OpenGraph tags from a URL.
-#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Card {
     // Required attributes
     url: Url,
@@ -120,8 +119,6 @@ impl Card {
         self.r#type == CardType::Rich
     }
 }
-
-impl Entity for Card {}
 
 /// The type of the preview card.
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy, Deserialize)]

--- a/src/entities/context.rs
+++ b/src/entities/context.rs
@@ -1,11 +1,10 @@
 use serde::Deserialize;
 use super::{
     Status,
-    Entity,
 };
 
 /// Represents the tree around the given status.
-#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Context {
     // Required attributes
     ancestors: Vec<Status>,
@@ -23,5 +22,3 @@ impl Context {
         &self.descendants
     }
 }
-
-impl Entity for Context {}

--- a/src/entities/emoji.rs
+++ b/src/entities/emoji.rs
@@ -4,7 +4,7 @@ use super::Entity;
 
 
 /// Represents a custom emoji.
-#[derive(Debug, Hash, Clone, Deserialize, mastors_derive::Entity)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Emoji {
     #[mastors(identifier)]
     shortcode: String,

--- a/src/entities/emoji.rs
+++ b/src/entities/emoji.rs
@@ -4,8 +4,9 @@ use super::Entity;
 
 
 /// Represents a custom emoji.
-#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize)]
+#[derive(Debug, Hash, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Emoji {
+    #[mastors(identifier)]
     shortcode: String,
     url: Url,
     static_url: Url,
@@ -39,8 +40,6 @@ impl Emoji {
         self.category.as_deref()
     }
 }
-
-impl Entity for Emoji {}
 
 /// Represents an array of [`Emoji`](./struct.Emoji.html)s.
 pub type Emojis = Vec<Emoji>;

--- a/src/entities/history.rs
+++ b/src/entities/history.rs
@@ -3,10 +3,9 @@ use crate::utils::{
     transform_string_to_u64,
     transform_string_to_usize,
 };
-use super::Entity;
 
 /// Represents daily usage history of a hashtag.
-#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Copy, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Copy, Deserialize, mastors_derive::Entity)]
 pub struct History {
     #[serde(deserialize_with = "transform_string_to_u64")]
     day: u64,
@@ -34,5 +33,3 @@ impl History {
         self.accounts
     }
 }
-
-impl Entity for History {}

--- a/src/entities/identity_proof.rs
+++ b/src/entities/identity_proof.rs
@@ -1,13 +1,13 @@
 use serde::Deserialize;
-use super::Entity;
 use crate::{
     DateTime,
     Url,
     Utc,
 };
+use super::Entity;
 
 /// Represents a proof from an external identity provider.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize, mastors_derive::Entity)]
 pub struct IdentityProof {
     provider: String,
     provider_username: String,
@@ -42,7 +42,6 @@ impl IdentityProof {
         self.updated_at
     }
 }
-impl Entity for IdentityProof {}
 
 /// Represents an array of [`IdentityProof`](./struct.IdentityProof.html)s.
 pub type IdentityProofs = Vec<IdentityProof>;

--- a/src/entities/instance.rs
+++ b/src/entities/instance.rs
@@ -6,7 +6,7 @@ use super::{
 };
 
 /// Represents the software instance of Mastodon running on this domain.
-#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Instance {
     uri: String,
     title: String,
@@ -96,8 +96,6 @@ impl Instance {
     }
 }
 
-impl Entity for Instance {}
-
 /// URLs of interest for clients apps.
 #[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize)]
 pub struct Urls {
@@ -112,7 +110,7 @@ impl Urls {
 }
 
 /// Statistics about how much information the instance contains.
-#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Copy, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Clone, Copy, Deserialize)]
 pub struct Stats {
     user_count: usize,
     status_count: usize,

--- a/src/entities/list.rs
+++ b/src/entities/list.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use super::Entity;
 
 /// Represents a list of some users that the authenticated user follows.
-#[derive(Debug, Hash, Clone, Deserialize, mastors_derive::Entity)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct List {
     #[mastors(identifier)]
     id: String,

--- a/src/entities/list.rs
+++ b/src/entities/list.rs
@@ -2,8 +2,9 @@ use serde::Deserialize;
 use super::Entity;
 
 /// Represents a list of some users that the authenticated user follows.
-#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize)]
+#[derive(Debug, Hash, Clone, Deserialize, mastors_derive::Entity)]
 pub struct List {
+    #[mastors(identifier)]
     id: String,
     title: String,
 }
@@ -19,8 +20,6 @@ impl List {
         self.title.as_str()
     }
 }
-
-impl Entity for List {}
 
 /// Represents an array of [`List`](./struct.List.html)s.
 pub type Lists = Vec<List>;

--- a/src/entities/markers.rs
+++ b/src/entities/markers.rs
@@ -1,12 +1,11 @@
 use serde::Deserialize;
 use crate::{ DateTime, Utc };
-use super::Entity;
 
 /// Represents the last read ID of the status and notification.
 /// 
 /// Any element to be None if call for the api method without specified elements.
 /// See [`/api/v1/markers`](../syncronous/methods/api/v1/markers).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Markers {
 	home: Option<Marker>,
 	notifications: Option<Marker>,
@@ -23,8 +22,6 @@ impl Markers {
 		self.notifications.as_ref()
 	}
 }
-
-impl Entity for Markers {}
 
 /// Represents the last read ID of the status or notification.
 #[derive(Debug, Clone, Deserialize)]
@@ -52,5 +49,3 @@ impl Marker {
 		self.version
 	}
 }
-
-impl Entity for Marker {}

--- a/src/entities/mention.rs
+++ b/src/entities/mention.rs
@@ -1,12 +1,13 @@
 use serde::Deserialize;
 use crate::Url;
-use super::Entity;
 
 /// Represents a mention of a user within the content of a status.
-#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Mention {
     // Required attributes
+    #[mastors(identifier)]
     id: String,
+
     username: String,
     url: Url,
     acct: String,
@@ -33,5 +34,3 @@ impl Mention {
         &self.acct
     }
 }
-
-impl Entity for Mention {}

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -53,14 +53,13 @@ use crate::{
 };
 
 /// Represents a no body response.
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, serde::Deserialize, mastors_derive::Entity)]
 pub struct Nothing {}
-impl Entity for Nothing {}
 
 /// The return value of POST /api/v1/statuses.
 /// 
 /// This endpoint returns `Status` or `ScheduledStatus` depending on whether the posted `Status` has a `scheduled_at` set.
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize, mastors_derive::Entity)]
 pub enum PostedStatus {
     Status(Box<Status>),
     ScheduledStatus(Box<ScheduledStatus>),
@@ -99,5 +98,3 @@ impl PostedStatus {
         }
     }
 }
-
-impl Entity for PostedStatus {}

--- a/src/entities/notification.rs
+++ b/src/entities/notification.rs
@@ -12,9 +12,10 @@ use super::{
 };
 
 /// Represents a receive notification for activity on your account or statuses.
-#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Notification {
     // Required attributes
+    #[mastors(identifier)]
     id: String,
 
     #[serde(deserialize_with = "transform_str_to_enum")]
@@ -90,8 +91,6 @@ impl Notification {
         self.r#type == NotificationType::FollowRequest
     }
 }
-
-impl Entity for Notification {}
 
 /// Represents an Array of [`Notification`](/entities/struct.Notification.html).
 pub type Notifications = Vec<Notification>;

--- a/src/entities/poll.rs
+++ b/src/entities/poll.rs
@@ -3,15 +3,14 @@ use crate::{
     DateTime,
     Utc,
 };
-use super::{
-    Emoji,
-    Entity,
-};
+use super::Emoji;
 
-#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 /// Represents a poll attached to a status.
 pub struct Poll {
+    #[mastors(identifier)]
     id: String,
+
     expires_at: DateTime<Utc>,
     expired: bool,
     multiple: bool,
@@ -74,8 +73,6 @@ impl Poll {
         &self.emojis
     }
 }
-
-impl Entity for Poll {}
 
 /// One of the answers for the poll.
 #[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize)]

--- a/src/entities/relationship.rs
+++ b/src/entities/relationship.rs
@@ -2,9 +2,11 @@
 use serde::Deserialize;
 use super::Entity;
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Deserialize)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Relationship {
+    #[mastors(identifier)]
     id: String,
+
     following: bool,
     requested: bool,
     endorsed: bool,
@@ -73,8 +75,6 @@ impl Relationship {
         self.blocked_by
     }
 }
-
-impl Entity for Relationship {}
 
 /// Represents an array of [`Relationship`](./struct.Relationship.html)s.
 pub type Relationships = Vec<Relationship>;

--- a/src/entities/scheduled_status.rs
+++ b/src/entities/scheduled_status.rs
@@ -11,10 +11,12 @@ use super::{
 };
 
 /// Represents a status that will be published at a future scheduled date.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct ScheduledStatus {
     // Required attributes
+    #[mastors(identifier)]
     id: String,
+
     scheduled_at: DateTime<Utc>,
     params: Box<Params>,
     media_attachments: Vec<Attachment>,
@@ -41,8 +43,6 @@ impl ScheduledStatus {
         &self.media_attachments
     }
 }
-
-impl Entity for ScheduledStatus {}
 
 /// Represents parameters of ScheduledStatus that will toot at scheduled date and time.
 #[derive(Debug, Clone, Deserialize)]

--- a/src/entities/status.rs
+++ b/src/entities/status.rs
@@ -19,10 +19,12 @@ use super::{
 };
 
 /// Represents a status posted by an account.
-#[derive(Debug, PartialEq, PartialOrd, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, mastors_derive::Entity)]
 pub struct Status {
     // Base attributes
+    #[mastors(identifier)]
     id: String,
+
     uri: Url,
     created_at: DateTime<Utc>,
     account: Box<Account>,
@@ -235,8 +237,6 @@ impl Status {
         self.visibility == Visibility::Direct
     }
 }
-
-impl Entity for Status {}
 
 /// Represents an array of [`Status`](./struct.Status.html)es.
 pub type Statuses = Vec<Status>;


### PR DESCRIPTION
This commit adds a procedural macro that auto-derives the `Entity` trait.
Procedural macros also automatically derive `Eq`, `Ord`, `PartialEq`,  `PartialOrd` and `Hash` if the entity struct has the field attributed with `mastors(identifier)`.
With this change, entities with an identifier attribute will be compared only by identifier.