### PR TITLE
Fix deserialize error

### DIFF
--- a/src/entities/card.rs
+++ b/src/entities/card.rs
@@ -1,5 +1,9 @@
 use serde::Deserialize;
 use crate::Url;
+use crate::utils::{
+    transform_string_to_option_string,
+    transform_string_to_option_url,
+};
 
 /// Represents a rich preview card that is generated using OpenGraph tags from a URL.
 #[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Deserialize, mastors_derive::Entity)]
@@ -10,15 +14,24 @@ pub struct Card {
     description: String,
     r#type: CardType,
 
-    //Optional attributes
+    /* Optional attributes
+     *
+     * These are optional, but they are never set to null or the key itself is omitted.
+     * If nothing a value, an empty string is set.
+     */
+    #[serde(deserialize_with = "transform_string_to_option_string")]
     author_name: Option<String>,
+    #[serde(deserialize_with = "transform_string_to_option_url")]
     author_url: Option<Url>,
+    #[serde(deserialize_with = "transform_string_to_option_string")]
     provider_name: Option<String>,
-    provider_uri: Option<Url>,
+    #[serde(deserialize_with = "transform_string_to_option_url")]
+    provider_url: Option<Url>,
     html: Option<String>,
     width: Option<u32>,
     height: Option<u32>,
     image: Option<Url>,
+    #[serde(deserialize_with = "transform_string_to_option_url")]
     embed_url: Option<Url>,
 }
 
@@ -59,8 +72,8 @@ impl Card {
     }
 
     /// Get a link to the provider of the original resource.
-    pub fn provider_uri(&self) -> Option<&Url> {
-        self.provider_uri.as_ref()
+    pub fn provider_url(&self) -> Option<&Url> {
+        self.provider_url.as_ref()
     }
 
     /// Get HTML to be used for generating the preview card.

--- a/src/error.rs
+++ b/src/error.rs
@@ -113,7 +113,7 @@ pub enum Error {
     ),
     */
 
-    #[error(display = "Failed to deserialize entity, perhaps, this is a bug of mastors")]
+    #[error(display = "Failed to deserialize entity, perhaps, this is a bug of mastors: {}", _0)]
     DeserializeJsonError(
         #[error(source, from)]
         serde_json::error::Error,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,5 +3,7 @@ mod serde;
 pub(crate) use self::serde::transform_string_to_usize;
 pub(crate) use self::serde::transform_string_to_u64;
 pub(crate) use self::serde::transform_string_to_i64;
+pub(crate) use self::serde::transform_string_to_option_string;
+pub(crate) use self::serde::transform_string_to_option_url;
 pub(crate) use crate::current_mode::utils::reqwest::check_response;
 pub(crate) use crate::current_mode::utils::reqwest::build_array_query;

--- a/src/utils/serde.rs
+++ b/src/utils/serde.rs
@@ -30,3 +30,29 @@ where
     let s: &str = Deserialize::deserialize(deserializer)?;
     i64::from_str_radix(s, 10).map_err(D::Error::custom)
 }
+
+use crate::Url;
+
+pub(crate) fn transform_string_to_option_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D:Deserializer<'de>
+{
+    let s: &str = Deserialize::deserialize(deserializer)?;
+    if s.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(s.to_string()))
+    }
+}
+pub(crate) fn transform_string_to_option_url<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+
+    let s: &str = Deserialize::deserialize(deserializer)?;
+    if s.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(Url::parse(s).map_err(D::Error::custom)?))
+    }
+}


### PR DESCRIPTION
Optional attributes of entity `Card` never set to null nor the key itself is omitted, set to empty string.
`Url` fails to parse if receives empty string.

This commit fixes to set the `Option::None` if `Card` receives the empty string.