### PR TITLE
Change API `mastors::api::v1::statuses`

### DIFF
--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -47,54 +47,6 @@ pub use scheduled_status::{ DeletedScheduledStatus, Params, ScheduledStatus, Sch
 pub use status::{ Status, Statuses };
 pub use tag::{ Tag, Trends };
 
-use crate::{
-    DateTime,
-    Utc,
-};
-
 /// Represents a no body response.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, serde::Deserialize, mastors_derive::Entity)]
 pub struct Nothing {}
-
-/// The return value of POST /api/v1/statuses.
-/// 
-/// This endpoint returns `Status` or `ScheduledStatus` depending on whether the posted `Status` has a `scheduled_at` set.
-#[derive(Debug, Clone, serde::Deserialize, mastors_derive::Entity)]
-pub enum PostedStatus {
-    Status(Box<Status>),
-    ScheduledStatus(Box<ScheduledStatus>),
-}
-
-impl PostedStatus {
-    /// Get an ID of this status or scheduled status.
-    pub fn id(&self) -> &str {
-        match self {
-            Self::Status(s) => s.id(),
-            Self::ScheduledStatus(s) => s.id(),
-        }
-    }
-
-    /// Get scheduled date and time if this status is scheduled.
-    pub fn scheduled_at(&self) -> Option<DateTime<Utc>> {
-        match self {
-            Self::Status(_) => None,
-            Self::ScheduledStatus(s) => Some(s.scheduled_at()),
-        }
-    }
-
-    /// Unwrap this `Posted` and get `Status` if this enum is Posted::Status.
-    pub fn status(&self) -> Option<&crate::entities::Status> {
-        match self {
-            Self::Status(s) => Some(s),
-            Self::ScheduledStatus(_) => None,
-        }
-    }
-
-    /// Unwrap this `Posted` and get `ScheduledStatus` if this enum is Posted::ScheduledStatus.
-    pub fn scheduled_status(&self) -> Option<&crate::entities::ScheduledStatus> {
-        match self {
-            Self::Status(_) => None,
-            Self::ScheduledStatus(s) => Some(s),
-        }
-    }
-}

--- a/src/entities/scheduled_status.rs
+++ b/src/entities/scheduled_status.rs
@@ -47,7 +47,7 @@ impl ScheduledStatus {
 /// Represents parameters of ScheduledStatus that will toot at scheduled date and time.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Params {
-    text: String,
+    text: Option<String>,
     application_id: u64,
     visibility: Option<Visibility>,
     in_reply_to_id: Option<String>,
@@ -60,8 +60,8 @@ pub struct Params {
 
 impl Params {
     /// Get a text of status that will posted at scheduled date and time.
-    pub fn text(&self) -> &str {
-        &self.text
+    pub fn text(&self) -> Option<&String> {
+        self.text.as_ref()
     }
 
     /// Get an application ID that used to create this scheduled status.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use chrono::{ DateTime, Utc };
 use err_derive::Error;
 use serde::Deserialize;
 
@@ -122,8 +123,8 @@ pub enum Error {
     #[error(display = "Received Unknown event type '{}'", _0)]
     UnknownEventTypeError(String),
 
-    #[error(display = "Status requires status or media_ids and does not allows attach both of media and polls: {}", _0)]
-    InvalidStatusError(String),
+    #[error(display = "Status requires status content text")]
+    InvalidStatusError,
 
     #[error(display = "Too many characters in a status (max: {}, got: {})", _1, _0)]
     TooManyCharactersError(usize, usize),
@@ -150,7 +151,10 @@ pub enum Error {
     DuplicatePollOptionError,
 
     #[error(display = "{} is a past date time", _0)]
-    PastDateTimeError(crate::DateTime<crate::Utc>),
+    PastDateTimeError(DateTime<Utc>),
+
+    #[error(display = "Schedule is too close: now: {}, scheduled: {}", _0, _1)]
+    ScheduleTooCloseError(DateTime<Utc>, DateTime<Utc>),
 
     #[error(display = "Voted option is duplicate")]
     DuplicateVoteOptionError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,13 +43,11 @@
 //! println!("{:#?}", instance);
 //! 
 //! // Post a toot with spoiler text and unlisted visibility.
-//! let posted_status = mastors::api::v1::statuses::post(&conn, "Toot!")
+//! let posted_status = mastors::api::v1::statuses::post(&conn)
+//!     .status("Toot!")
 //!     .spoiler_text("Spoiler!")
 //!     .unlisted()
-//!     .send()?
-//!     .status()
-//!     .unwrap()
-//!     .clone();
+//!     .send()?;
 //! println!("{:#?}", posted_status);
 //! 
 //! // Get a toot that posted in the previous step.
@@ -173,8 +171,8 @@ pub mod prelude {
 
     /// Toot a simple text.
     pub fn toot(conn: &Connection, body: impl AsRef<str>) -> crate::Result<crate::entities::Status> {
-        match crate::api::v1::statuses::post(conn, body).send() {
-            Ok(posted) => Ok(posted.status().unwrap().clone()),
+        match crate::api::v1::statuses::post(conn).status(body).send() {
+            Ok(posted) => Ok(posted),
             Err(e) => Err(e),
         }
     }

--- a/src/synchronous/methods/api/v1/polls.rs
+++ b/src/synchronous/methods/api/v1/polls.rs
@@ -135,13 +135,12 @@ mod tests {
     #[test]
     fn test_vote_to_poll() {
         let conn = Connection::new().unwrap();
-        let posted = crate::api::v1::statuses::post_with_poll(&conn, "test_vote_to_poll", ["a", "b", "c"], 3600)
+        let posted = crate::api::v1::statuses::post(&conn)
+            .status("test_vote_to_poll")
+            .poll(["a", "b", "c"], 3600)
             .poll_multiple()
             .send()
-            .unwrap()
-            .status()
-            .unwrap()
-            .clone();
+            .unwrap();
 
         let voted = super::id::votes::post(&conn, posted.poll().unwrap().id(), [0, 1])
             .send()

--- a/src/synchronous/methods/api/v1/scheduled_statuses.rs
+++ b/src/synchronous/methods/api/v1/scheduled_statuses.rs
@@ -209,41 +209,31 @@ mod tests {
             id::delete(&conn, ss.id()).send().unwrap();
         }
 
-        let posted1 = statuses::post(&conn, "first")
+        let posted1 = statuses::post(&conn)
+            .status("first")
             .scheduled_at(scheduled_at)
             .send()
-            .unwrap()
-            .scheduled_status()
-            .unwrap()
-            .clone();
-        let posted2 = statuses::post(&conn, "second")
+            .unwrap();
+        let posted2 = statuses::post(&conn)
+            .status("second")
             .scheduled_at(scheduled_at)
             .send()
-            .unwrap()
-            .scheduled_status()
-            .unwrap()
-            .clone();
-        let posted3 = statuses::post(&conn, "third")
+            .unwrap();
+        let posted3 = statuses::post(&conn)
+            .status("third")
             .scheduled_at(scheduled_at)
             .send()
-            .unwrap()
-            .scheduled_status()
-            .unwrap()
-            .clone();
-        let posted4 = statuses::post(&conn, "fourth")
+            .unwrap();
+        let posted4 = statuses::post(&conn)
+            .status("fourth")
             .scheduled_at(scheduled_at)
             .send()
-            .unwrap()
-            .scheduled_status()
-            .unwrap()
-            .clone();
-        let posted5 = statuses::post(&conn, "fifth")
+            .unwrap();
+        let posted5 = statuses::post(&conn)
+            .status("fifth")
             .scheduled_at(scheduled_at)
             .send()
-            .unwrap()
-            .scheduled_status()
-            .unwrap()
-            .clone();
+            .unwrap();
 
         let mut posted_ids = vec![
             posted1.id().to_string(),

--- a/src/synchronous/methods/api/v1/statuses/id/bookmarks.rs
+++ b/src/synchronous/methods/api/v1/statuses/id/bookmarks.rs
@@ -86,12 +86,10 @@ mod tests {
 	fn test_bookmark_and_unbookmark() {
 		let conn = crate::Connection::new().unwrap();
 
-		let status = crate::api::v1::statuses::post(&conn, "bookmark and unbookmark.")
+		let status = crate::api::v1::statuses::post(&conn)
+			.status("bookmark and unbookmark.")
 			.send()
-			.unwrap()
-			.status()
-			.unwrap()
-			.clone();
+			.unwrap();
 
 		let bookmarked = bookmark::post(&conn, status.id()).send().unwrap();
 		assert_eq!(status.id(), bookmarked.id());

--- a/src/synchronous/methods/api/v1/statuses/id/contexts.rs
+++ b/src/synchronous/methods/api/v1/statuses/id/contexts.rs
@@ -59,33 +59,25 @@ mod tests {
 
         let conn = crate::Connection::new().unwrap();
 
-        let first = statuses::post(&conn, "first")
+        let first = statuses::post(&conn)
+            .status("first")
             .send()
-            .unwrap()
-            .status()
-            .unwrap()
-            .clone();
-        let second = statuses::post(&conn, "second")
+            .unwrap();
+        let second = statuses::post(&conn)
+            .status("second")
             .in_reply_to_id(first.id())
             .send()
-            .unwrap()
-            .status()
-            .unwrap()
-            .clone();
-        let third = statuses::post(&conn, "third")
+            .unwrap();
+        let third = statuses::post(&conn)
+            .status("third")
             .in_reply_to_id(second.id())
             .send()
-            .unwrap()
-            .status()
-            .unwrap()
-            .clone();
-        let fourth = statuses::post(&conn, "fourth")
+            .unwrap();
+        let fourth = statuses::post(&conn)
+            .status("fourth")
             .in_reply_to_id(third.id())
             .send()
-            .unwrap()
-            .status()
-            .unwrap()
-            .clone();
+            .unwrap();
 
         let contexts = context::get(&conn, third.id()).send().unwrap();
         let ancestors = contexts.ancestors().iter().map(|status| status.id().to_owned()).collect::<Vec<String>>();

--- a/src/synchronous/methods/api/v1/statuses/id/favourites.rs
+++ b/src/synchronous/methods/api/v1/statuses/id/favourites.rs
@@ -122,12 +122,10 @@ mod tests {
     #[test]
     fn test_favourite_unfavourite_status() {
         let conn = crate::Connection::new().unwrap();
-        let status = crate::api::v1::statuses::post(&conn, "favourite unfavourite.")
+        let status = crate::api::v1::statuses::post(&conn)
+            .status("favourite unfavourite.")
             .send()
-            .unwrap()
-            .status()
-            .unwrap()
-            .clone();
+            .unwrap();
         let myself = status.account();
 
         let favourited = favourite::post(&conn, status.id()).send().unwrap();

--- a/src/synchronous/methods/api/v1/statuses/id/mutes.rs
+++ b/src/synchronous/methods/api/v1/statuses/id/mutes.rs
@@ -88,19 +88,15 @@ mod tests {
 	#[test]
 	fn test_mute_unmute() {
 		let conn = Connection::new().unwrap();
-		let posted = statuses::post(&conn, "mute unmute")
+		let posted = statuses::post(&conn)
+			.status("mute unmute")
 			.send()
-			.unwrap()
-			.status()
-			.unwrap()
-			.clone();
-		let replied = statuses::post(&conn, "mute unmute reply")
+			.unwrap();
+		let replied = statuses::post(&conn)
+			.status("mute unmute reply")
 			.in_reply_to_id(posted.id())
 			.send()
-			.unwrap()
-			.status()
-			.unwrap()
-			.clone();
+			.unwrap();
 
 		let muted = mute::post(&conn, posted.id()).send().unwrap();
 		assert_eq!(posted.id(), muted.id());

--- a/src/synchronous/methods/api/v1/statuses/id/pins.rs
+++ b/src/synchronous/methods/api/v1/statuses/id/pins.rs
@@ -88,12 +88,10 @@ mod tests {
 	#[test]
 	fn test_pin_unpin() {
 		let conn = Connection::new().unwrap();
-		let posted = statuses::post(&conn, "pin unpin")
+		let posted = statuses::post(&conn)
+			.status("pin unpin")
 			.send()
-			.unwrap()
-			.status()
-			.unwrap()
-			.clone();
+			.unwrap();
 
 		let pinned = pin::post(&conn, posted.id()).send().unwrap();
 		assert_eq!(posted.id(), pinned.id());

--- a/src/synchronous/methods/api/v1/statuses/id/reblogs.rs
+++ b/src/synchronous/methods/api/v1/statuses/id/reblogs.rs
@@ -153,12 +153,10 @@ mod tests {
 	#[test]
 	fn test_reblog_unreblog() {
 		let conn = Connection::new().unwrap();
-		let posted = statuses::post(&conn, "reblog unreblog")
+		let posted = statuses::post(&conn)
+			.status("reblog unreblog")
 			.send()
-			.unwrap()
-			.status()
-			.unwrap()
-			.clone();
+			.unwrap();
 		let myself = posted.account();
 
 		let reblogged = reblog::post(&conn, posted.id()).send().unwrap();

--- a/src/synchronous/methods/api/v1/timelines/tag.rs
+++ b/src/synchronous/methods/api/v1/timelines/tag.rs
@@ -147,12 +147,11 @@ mod tests {
     fn test_get_hashtag_timeline() {
         let conn = Connection::new().unwrap();
 
-        let posted = statuses::post(&conn, "test hashtag timeline #mastorstesthashtagmastorstesthashtag")
+        let posted = statuses::post(&conn)
+            .status("test hashtag timeline #mastorstesthashtagmastorstesthashtag")
             .send()
-            .unwrap()
-            .status()
-            .unwrap()
-            .clone();
+            .unwrap();
+
         let got = get(&conn, "mastorstesthashtagmastorstesthashtag").send().unwrap();
         assert!(! got.is_empty());
         assert_eq!(got.get(0).unwrap().id(), posted.id());


### PR DESCRIPTION
Make to do not forcibly absorb the difference of `Status` and `ScheduledStatus`.
But this change also has concern that the type is changed in the middle of the method chain.

In the following example occurs compilation error because each match arm returns the different type.

```rust
let conn = Connection::new()?;
let poll_options = Some(["a", "b"]);

let post = api::v1::statuses::post(&conn)
    .status("Toot");

let post = match poll_options {
    Some(po) => post.poll(po, 3600), // Returns PostStatusesWithPoll
    None => post, // Returns PostStatusSimple
}
```